### PR TITLE
hash comments are deprecated, replace with ; comments

### DIFF
--- a/modules/mailhog/templates/mailhog.ini.erb
+++ b/modules/mailhog/templates/mailhog.ini.erb
@@ -1,3 +1,3 @@
-# Note: Uses dummy email due to issue in MailHog's processing.
-# See https://github.com/mailhog/mhsendmail/issues/3
+; Note: Uses dummy email due to issue in MailHog's processing.
+; See https://github.com/mailhog/mhsendmail/issues/3
 sendmail_path = "/usr/bin/env mailhog sendmail test@example.org"


### PR DESCRIPTION
These generate PHP deprecation warnings during provisioning